### PR TITLE
Use unicode block for rendering of QR string

### DIFF
--- a/src/render/string.rs
+++ b/src/render/string.rs
@@ -11,7 +11,7 @@ pub trait Element: Copy {
 
 impl Element for char {
     fn default_color(color: Color) -> Self {
-        color.select('#', ' ')
+        color.select('█', ' ')
     }
 
     fn strlen(self) -> usize {
@@ -25,7 +25,7 @@ impl Element for char {
 
 impl<'a> Element for &'a str {
     fn default_color(color: Color) -> Self {
-        color.select("#", " ")
+        color.select("█", " ")
     }
 
     fn strlen(self) -> usize {

--- a/src/render/string.rs
+++ b/src/render/string.rs
@@ -106,7 +106,7 @@ fn test_render_to_string() {
         Color::Light, Color::Dark,
     ];
     let image: String = Renderer::<char>::new(colors, 2, 1).build();
-    assert_eq!(&image, "    \n #  \n  # \n    ");
+    assert_eq!(&image, "    \n █  \n  █ \n    ");
 
     let image2 = Renderer::new(colors, 2, 1)
         .light_color("A")


### PR DESCRIPTION
Just a quick change of # to a unicode full block 
https://en.wikipedia.org/wiki/Block_Elements
U+2588 | █ | Full block
Makes the QR code output from the terminal actually scannable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kennytm/qrcode-rust/15)
<!-- Reviewable:end -->
