### PR TITLE
make QrError std::error::Error

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -41,6 +41,12 @@ impl Display for QrError {
     }
 }
 
+impl ::std::error::Error for QrError {
+    fn description(&self) -> &'static str {
+        "QrError"
+    }
+}
+
 /// `QrResult` is a convenient alias for a QR code generation result.
 pub type QrResult<T> = Result<T, QrError>;
 


### PR DESCRIPTION
I thought it would be nice for QrError to be std::error:Error. It seems to already have all the functionality that is needed (I don't think the methods on srd::error::Error need to be overridden at all in this case). If you've already thought about it and discarded the idea, then please just close this PR, as I'm doing this in a somewhat driveby way.