### PR TITLE
Fix TODO: use sum insted of left fold

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -332,8 +332,9 @@ impl<I: Iterator<Item = Segment>> Iterator for Optimizer<I> {
 
 /// Computes the total encoded length of all segments.
 pub fn total_encoded_len(segments: &[Segment], version: Version) -> usize {
-    // TODO revert to `.map().sum()` after `sum()` is stable.
-    segments.iter().fold(0, |acc, seg| acc + seg.encoded_len(version))
+    segments.iter()
+        .map(|seg| seg.encoded_len(version))
+        .sum()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As I understand from rustlang docs on the [sum trait](https://doc.rust-lang.org/std/iter/trait.Sum.html), it is available in stable since 1.12.

Let me know if I am missing something and there is a reason this cannot be merged.