### PR TITLE
Don't depend on image crate default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ is-it-maintained-open-issues = { repository = "kennytm/qrcode-rust" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-image = { version = "0.20", optional = true }
+image = { version = "0.20", default-features = false, optional = true }
 checked_int_cast = "1"
 
 [features]


### PR DESCRIPTION
The `image` crate has a lot of dependencies that pull unnecessary bloat into crates that depend on `qrcode`. `qrcode` doesn't use any of `image`'s dependencies, so it makes sense to turn them off.