### PR TITLE
make push_number_checked public to handle structured append

### DIFF
--- a/src/bits.rs
+++ b/src/bits.rs
@@ -63,7 +63,7 @@ impl Bits {
     /// that the number does not overflow the bits.
     ///
     /// Returns `Err(QrError::DataTooLong)` on overflow.
-    fn push_number_checked(&mut self, n: usize, number: usize) -> QrResult<()> {
+    pub fn push_number_checked(&mut self, n: usize, number: usize) -> QrResult<()> {
         if n > 16 || number >= (1 << n) {
             Err(QrError::DataTooLong)
         } else {


### PR DESCRIPTION
I need to generate qr codes for data up to 10kb or so, thus I need to split those with the structured append mode, I did a quick test but this need the method `push_number_checked` to be exposed

```
#[test]
    fn test_structured_append() {
        // from example https://segno.readthedocs.io/en/stable/structured-append.html#structured-append
        let data = "I read the news today oh boy".as_bytes();
        let data_half = "I read the new".as_bytes();
        let parity = data.iter().fold(0u8, |acc, &x| acc ^ x);
        let mut bits = Bits::new(Version::Normal(1));
        bits.push_mode_indicator(ExtendedMode::StructuredAppend).unwrap();
        bits.push_number_checked(4, 0).unwrap();  // first element of the sequence
        bits.push_number_checked(4, 1).unwrap();  // total length of the sequence (means 2)
        bits.push_number_checked(8, parity as usize).unwrap();  //parity of the complete data
        bits.push_byte_data(data_half).unwrap();
        bits.push_terminator(EcLevel::L).unwrap();
        assert_eq!(hex::encode(bits.clone().into_bytes()), "3013940e49207265616420746865206e657700");  // raw bytes of the first qr code of the example
    }
```