### PR TITLE
fix: Add newline after qr code and print usage if incorrect number of…

### DIFF
--- a/src/bin/qrencode.rs
+++ b/src/bin/qrencode.rs
@@ -1,8 +1,12 @@
 use std::env;
 
 pub fn main() {
-    let arg = env::args().nth(1).unwrap();
-    let code = qrcode::QrCode::new(arg.as_bytes()).unwrap();
+    if env::args().len() == 2 {
+        let arg = env::args().nth(1).unwrap();
+        let code = qrcode::QrCode::new(arg.as_bytes()).unwrap();
 
-    print!("{}", code.render().dark_color("\x1b[7m  \x1b[0m").light_color("\x1b[49m  \x1b[0m").build());
+        println!("{}", code.render().dark_color("\x1b[7m  \x1b[0m").light_color("\x1b[49m  \x1b[0m").build());
+    } else {
+        println!("Usage: {} INPUT_TEXT", env::args().nth(0).unwrap());
+    }
 }


### PR DESCRIPTION
… args passed

Closes issue #47 and adds a newline following print out of QR code to stdout.