### PR TITLE
Replace the `checked_int_cast` dependency with `std::convert::TryInto`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 image = { version = "0.23", default-features = false, optional = true }
-checked_int_cast = "1"
 
 [dev-dependencies]
 image = "0.23"

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 #[cfg(debug_assertions)]
-use checked_int_cast::CheckedIntCast;
+use std::convert::TryInto;
 
 pub trait Truncate {
     fn truncate_as_u8(self) -> u8;
@@ -27,13 +27,10 @@ trait ExpectOrOverflow {
     fn expect_or_overflow<D: Display>(self, value: D, ty: &str) -> Self::Output;
 }
 
-impl<T> ExpectOrOverflow for Option<T> {
+impl<T, E> ExpectOrOverflow for Result<T, E> {
     type Output = T;
     fn expect_or_overflow<D: Display>(self, value: D, ty: &str) -> Self::Output {
-        match self {
-            Some(v) => v,
-            None => panic!("{} overflows {}", value, ty),
-        }
+        self.unwrap_or_else(|_err| panic!("{} overflows {}", value, ty))
     }
 }
 
@@ -42,23 +39,23 @@ macro_rules! impl_as {
         #[cfg(debug_assertions)]
         impl As for $ty {
             fn as_u16(self) -> u16 {
-                self.as_u16_checked().expect_or_overflow(self, "u16")
+                self.try_into().expect_or_overflow(self, "u16")
             }
 
             fn as_i16(self) -> i16 {
-                self.as_i16_checked().expect_or_overflow(self, "i16")
+                self.try_into().expect_or_overflow(self, "i16")
             }
 
             fn as_u32(self) -> u32 {
-                self.as_u32_checked().expect_or_overflow(self, "u32")
+                self.try_into().expect_or_overflow(self, "u32")
             }
 
             fn as_usize(self) -> usize {
-                self.as_usize_checked().expect_or_overflow(self, "usize")
+                self.try_into().expect_or_overflow(self, "usize")
             }
 
             fn as_isize(self) -> isize {
-                self.as_isize_checked().expect_or_overflow(self, "usize")
+                self.try_into().expect_or_overflow(self, "usize")
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 #![cfg_attr(feature = "bench", doc(include = "../README.md"))]
 // ^ make sure we can test our README.md.
 
+use std::convert::TryInto;
 use std::ops::Index;
 
 pub mod bits;
@@ -49,7 +50,6 @@ pub use crate::types::{Color, EcLevel, QrResult, Version};
 
 use crate::cast::As;
 use crate::render::{Pixel, Renderer};
-use checked_int_cast::CheckedIntCast;
 
 /// The encoded QR code symbol.
 #[derive(Clone)]
@@ -186,8 +186,8 @@ impl QrCode {
     /// Checks whether a module at coordinate (x, y) is a functional module or
     /// not.
     pub fn is_functional(&self, x: usize, y: usize) -> bool {
-        let x = x.as_i16_checked().expect("coordinate is too large for QR code");
-        let y = y.as_i16_checked().expect("coordinate is too large for QR code");
+        let x = x.try_into().expect("coordinate is too large for QR code");
+        let y = y.try_into().expect("coordinate is too large for QR code");
         canvas::is_functional(self.version, self.version.width(), x, y)
     }
 


### PR DESCRIPTION
The `checked_int_cast` crate (version 1.0.0 released on 2015-09-07) has been made obsolete with the introduction of the `std::convert::TryInfo` trait (the RFC has been started on 2016-03-10 - see https://rust-lang.github.io/rfcs/1542-try-from.html.  The `qrcode` depends on Rust 2018 edition and therefore it can depend on the presence of the `std::convert::TryInfo` trait.

Based on the above, this commit drops the `checked_int_cast` dependency and replaces it with usage of the standard `TryInto` trait.  This commit should have no impact on the behavior, nor the API of the `qrcode` crate.  OTOH, removing the dependency will have a small positive impact on users of the `qrcode` crate - they no longer will have to fetch, build, audit, etc. the `checked_int_cast` crate.