### PR TITLE
Add `#![no_std]` compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT OR Apache-2.0"
 version = "0.12.0"
 edition = "2018"
 authors = ["kennytm <kennytm@gmail.com>"]
-keywords = ["qrcode"]
+keywords = ["qrcode", "no_std"]
 repository = "https://github.com/kennytm/qrcode-rust"
 readme = "README.md"
 documentation = "http://docs.rs/qrcode"
@@ -22,15 +22,17 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 image = { version = "0.23", default-features = false, optional = true }
-checked_int_cast = "1"
+checked_int_cast = { version = "1", optional = true }
 
 [dev-dependencies]
 image = "0.23"
 
 [features]
-default = ["image", "svg"]
+default = ["image", "svg", "std"]
 bench = []
-svg = []
+std = ["dep:checked_int_cast"]
+image = ["std", "dep:image"]
+svg = ["std"]
 
 [[bin]]
 name = "qrencode"

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -1,6 +1,7 @@
 //! The `bits` module encodes binary data into raw bits used in a QR code.
 
-use std::cmp::min;
+use alloc::vec::Vec;
+use core::cmp::min;
 
 #[cfg(feature = "bench")]
 extern crate test;
@@ -855,6 +856,7 @@ impl Bits {
 mod encode_tests {
     use crate::bits::Bits;
     use crate::types::{EcLevel, QrError, QrResult, Version};
+    use alloc::vec::Vec;
 
     fn encode(data: &[u8], version: Version, ec_level: EcLevel) -> QrResult<Vec<u8>> {
         let mut bits = Bits::new(version);

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -9,7 +9,12 @@
 //!     c.apply_mask(MaskPattern::Checkerboard);
 //!     let bools = c.to_bools();
 
-use std::cmp::max;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::max;
+
+#[cfg(test)]
+use alloc::string::String;
 
 use crate::cast::As;
 use crate::types::{Color, EcLevel, Version};
@@ -1188,6 +1193,7 @@ impl Iterator for DataModuleIter {
 mod data_iter_tests {
     use crate::canvas::DataModuleIter;
     use crate::types::Version;
+    use alloc::vec::Vec;
 
     #[test]
     fn test_qr() {

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -1,6 +1,6 @@
-use std::fmt::Display;
+use core::fmt::Display;
 
-#[cfg(debug_assertions)]
+#[cfg(all(debug_assertions, feature = "std"))]
 use checked_int_cast::CheckedIntCast;
 
 pub trait Truncate {
@@ -39,7 +39,7 @@ impl<T> ExpectOrOverflow for Option<T> {
 
 macro_rules! impl_as {
     ($ty:ty) => {
-        #[cfg(debug_assertions)]
+        #[cfg(all(debug_assertions, feature = "std"))]
         impl As for $ty {
             fn as_u16(self) -> u16 {
                 self.as_u16_checked().expect_or_overflow(self, "u16")
@@ -62,7 +62,7 @@ macro_rules! impl_as {
             }
         }
 
-        #[cfg(not(debug_assertions))]
+        #[cfg(any(not(debug_assertions), not(feature = "std")))]
         impl As for $ty {
             fn as_u16(self) -> u16 {
                 self as u16

--- a/src/ec.rs
+++ b/src/ec.rs
@@ -1,6 +1,7 @@
 //! The `ec` module applies the Reed-Solomon error correction codes.
 
-use std::ops::Deref;
+use alloc::vec::Vec;
+use core::ops::Deref;
 
 use crate::types::{EcLevel, QrResult, Version};
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,6 +1,6 @@
 //! Find the optimal data mode sequence to encode a piece of data.
 use crate::types::{Mode, Version};
-use std::slice::Iter;
+use alloc::slice::Iter;
 
 #[cfg(feature = "bench")]
 extern crate test;
@@ -155,6 +155,7 @@ impl<'a> Iterator for Parser<'a> {
 mod parse_tests {
     use crate::optimize::{Parser, Segment};
     use crate::types::Mode;
+    use alloc::vec::Vec;
 
     fn parse(data: &[u8]) -> Vec<Segment> {
         Parser::new(data).collect()
@@ -338,6 +339,7 @@ pub fn total_encoded_len(segments: &[Segment], version: Version) -> usize {
 mod optimize_tests {
     use crate::optimize::{total_encoded_len, Optimizer, Segment};
     use crate::types::{Mode, Version};
+    use alloc::vec::Vec;
 
     fn test_optimization_result(given: Vec<Segment>, expected: Vec<Segment>, version: Version) {
         let prev_len = total_encoded_len(&*given, version);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::cast::As;
 use crate::types::Color;
-use std::cmp::max;
+use core::cmp::max;
 
 pub mod image;
 pub mod string;

--- a/src/render/string.rs
+++ b/src/render/string.rs
@@ -3,6 +3,8 @@
 use crate::cast::As;
 use crate::render::{Canvas as RenderCanvas, Pixel};
 use crate::types::Color;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub trait Element: Copy {
     fn default_color(color: Color) -> Self;

--- a/src/render/unicode.rs
+++ b/src/render/unicode.rs
@@ -1,6 +1,8 @@
 //! UTF-8 rendering, with 2 pixels per symbol.
 
 use crate::render::{Canvas as RenderCanvas, Color, Pixel};
+use alloc::string::String;
+use alloc::vec::Vec;
 
 const CODEPAGE: [&str; 4] = [" ", "\u{2584}", "\u{2580}", "\u{2588}"];
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,8 @@
 use crate::cast::As;
-use std::cmp::{Ordering, PartialOrd};
-use std::default::Default;
-use std::fmt::{Display, Error, Formatter};
-use std::ops::Not;
+use core::cmp::{Ordering, PartialOrd};
+use core::default::Default;
+use core::fmt::{Display, Error, Formatter};
+use core::ops::Not;
 
 //------------------------------------------------------------------------------
 //{{{ QrResult
@@ -41,7 +41,7 @@ impl Display for QrError {
     }
 }
 
-impl ::std::error::Error for QrError {}
+impl ::core::error::Error for QrError {}
 
 /// `QrResult` is a convenient alias for a QR code generation result.
 pub type QrResult<T> = Result<T, QrError>;


### PR DESCRIPTION
- [x] Add `std` feature flag to allow disabling std lib for no_std environments
- [ ] Add tests to ensure no_std support isn't broken by future changes
- [ ] Add documentation on how to use library in a no_std environment

Note: `extern crate alloc` is still required, but I didn't want to add another `alloc` feature flag, since virtually nothing would be possible without it.