### PR TITLE
Bump `image` to 0.25

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        rustc: [1.61.0, stable] # MSVR and current stable rustc
+        rustc: [1.67.1, stable] # MSVR and current stable rustc
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,10 @@ exclude = [
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-image = { version = "0.24", default-features = false, optional = true }
+image = { version = "0.25", default-features = false, optional = true }
 
 [dev-dependencies]
-image = "0.24"
+image = "0.25"
 
 [features]
 default = ["image", "svg"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "QR code encoder in Rust"
 license = "MIT OR Apache-2.0"
 version = "0.13.0"
 edition = "2021"
+rust-version = "1.67.1"
 authors = ["kennytm <kennytm@gmail.com>"]
 keywords = ["qrcode"]
 repository = "https://github.com/kennytm/qrcode-rust"


### PR DESCRIPTION
- Bump `image` to 0.25.
- Since the MSRV of `image` 0.25 is 1.67.1, change the MSRV of this crate to 1.67.1.
- Add the `rust-version` field to the `Cargo.toml`.

Closes #62