### PR TITLE
pic: Improve rendered image quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ output that renders as follows:
 
 ```pic
 maxpswid=29;maxpsht=29;movewid=0;moveht=1;boxwid=1;boxht=1
-define p { box wid $3 ht $4 fill 1 with .nw at $1,-$2 }
+define p { box wid $3 ht $4 fill 1 thickness 0.1 with .nw at $1,-$2 }
 box wid maxpswid ht maxpsht with .nw at 0,0
 p(4,4,1,1)
 p(5,4,1,1)

--- a/src/render/pic.rs
+++ b/src/render/pic.rs
@@ -44,7 +44,7 @@ impl RenderCanvas for Canvas {
             pic: format!(
                 concat!(
                     "maxpswid={w};maxpsht={h};movewid=0;moveht=1;boxwid=1;boxht=1\n",
-                    "define p {{ box wid $3 ht $4 fill 1 with .nw at $1,-$2 }}\n",
+                    "define p {{ box wid $3 ht $4 fill 1 thickness 0.1 with .nw at $1,-$2 }}\n",
                     "box wid maxpswid ht maxpsht with .nw at 0,0\n",
                 ),
                 w = width,

--- a/src/test_annex_i_micro_qr_as_pic.pic
+++ b/src/test_annex_i_micro_qr_as_pic.pic
@@ -1,5 +1,5 @@
 maxpswid=17;maxpsht=17;movewid=0;moveht=1;boxwid=1;boxht=1
-define p { box wid $3 ht $4 fill 1 with .nw at $1,-$2 }
+define p { box wid $3 ht $4 fill 1 thickness 0.1 with .nw at $1,-$2 }
 box wid maxpswid ht maxpsht with .nw at 0,0
 p(2,2,1,1)
 p(3,2,1,1)

--- a/src/test_annex_i_qr_as_pic.pic
+++ b/src/test_annex_i_qr_as_pic.pic
@@ -1,5 +1,5 @@
 maxpswid=232;maxpsht=232;movewid=0;moveht=1;boxwid=1;boxht=1
-define p { box wid $3 ht $4 fill 1 with .nw at $1,-$2 }
+define p { box wid $3 ht $4 fill 1 thickness 0.1 with .nw at $1,-$2 }
 box wid maxpswid ht maxpsht with .nw at 0,0
 p(32,32,8,8)
 p(40,32,8,8)


### PR DESCRIPTION
by reducing the line thickness of each pixel to minimize overlap.

Hi @kennytm, 👋🙂
while working on adding support for PIC output format to [`sorairolake/qrtool`](http://github.com/sorairolake/qrtool) I noticed that in certain configuration the pixel may overlap, resulting in a somewhat "smudged" look of the QR code.
The codes functionality is not affected by this, yet I think having the code appear "crispy" is desirable. Judging from the examples below, what are your thoughts on this?

| Before | After
| --- | ---
| ![Before](https://github.com/kennytm/qrcode-rust/assets/16507/c92eadfd-764a-4e18-934d-baf0405b8d4a) | ![After](https://github.com/kennytm/qrcode-rust/assets/16507/3c017d0d-901c-4987-b379-8827afd9375b)

