### PR TITLE
Fix string generation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ use qrcode::QrCode;
 fn main() {
     let code = QrCode::new(b"Hello").unwrap();
     let string = code.render::<char>()
+        .dark_color('#')
         .quiet_zone(false)
         .module_dimensions(2, 1)
         .build();


### PR DESCRIPTION
This is because a string used for dark color have changed in #15.